### PR TITLE
Allow multiple observers to affect aggregation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ Reactively publish aggregations.
 
 This helper can be used to reactively publish the results of an aggregation.
 
-Based on `jcbernack:reactive-aggregate`.
+Originally based on `jcbernack:reactive-aggregate`.
 
 This clone removes the dependency on `meteorhacks:reactive-aggregate` and instead uses the underlying MongoDB Nodejs library. In addition, it uses ES6/7 coding, including `async` and `await` and `import/export` syntax, so should be `import`ed into your (server) codebase where it's needed.
 
-In spite of those changes, the API is basically unchanged. I have added a new `aggregationOptions` object to the `options`, which may be used to pass in any of the [standard aggregation options](http://mongodb.github.io/node-mongodb-native/2.2/api/Collection.html#aggregate).
+In spite of those changes, the API is basically unchanged. However, there are a few additional properties of the `options` parameter. See the notes in the **Usage** section.
 
 ## Usage
 
@@ -27,12 +27,17 @@ Meteor.publish('nameOfPublication', function() {
 - `pipeline` is the aggregation pipeline to execute.
 - `options` provides further options:
   - `aggregationOptions` can be used to add further, aggregation-specific options. See [standard aggregation options](http://mongodb.github.io/node-mongodb-native/2.2/api/Collection.html#aggregate) for more information.
-  - `observeSelector` can be given to improve efficiency. This selector is used for observing the collection.
-  (e.g. `{ authorId: { $exists: 1 } }`)
-  - `observeOptions` can be given to limit fields, further improving efficiency. Ideally used to limit fields on your query.
-  If none are given any change to the collection will cause the aggregation to be re-evaluated.
-  (e.g. `{ limit: 10, sort: { createdAt: -1 } }`)
   - `clientCollection` defaults to the same name as the original collection, but can be overridden to send the results to a differently named client-side collection.
+  - `observers`: An array of cursors. Each cursor is the result of a `Collection.find()`. Each of the supplied cursors will have an observer attached, so any change detected (and based on the selection criteria in the `find`) will re-run the aggregation pipeline.
+  - `debounceCount`: An integer representing the number of observer changes across all observers before the aggregation will be re-run. Defaults to 100.
+  - `debounceDelay`: An integer representing the maximum number of milli-seconds to wait for observer changes before the aggregation is re-run. Defaults to 100.
+
+  The following parameters are **deprecated** and will be removed in a later version. Both these parameters are now effectively absorbed into the `observers` option and if required should be added as a cursor (or another cursor) to the array of cursors in that.
+  - ~~`observeSelector` can be given to improve efficiency. This selector is used for observing the collection.
+  (e.g. `{ authorId: { $exists: 1 } }`)~~
+  - ~~`observeOptions` can be given to limit fields, further improving efficiency. Ideally used to limit fields on your query.
+  If none are given any change to the collection will cause the aggregation to be re-evaluated.
+  (e.g. `{ limit: 10, sort: { createdAt: -1 } }`)~~
 
 ## Quick Example
 

--- a/README.md
+++ b/README.md
@@ -23,10 +23,12 @@ Meteor.publish('nameOfPublication', function() {
 ```
 
 - `sub` should always be `this` in a publication.
-- `collection` is the Mongo.Collection instance to query.
+- `collection` is the Mongo.Collection instance to query, or `null`. Setting `collection` to `null` disables backwards compatibility, in which an observer is automatically added on the collection.
+
+  The backwards-compatible, deprecated options `observeSelector` and `observeOptions` will continue to be honoured when `collection` is a `Mongo.Collection`, but the recommended approach is to use `null` and `options.observers`, which replaces the original method with something more versatile. There is no guarantee that deprecated options will continue to be honoured in future releases.
+
 - `pipeline` is the aggregation pipeline to execute.
 - `options` provides further options:
-  - `autoObserver`: Set to `false` to disable the automatic addition of an observer on the base collection. The default value is `true`, which provides backwards compatibility for the majority of aggregations. :hand: However, note that when the observer is automatically added it will make use of the deprecated options `observeSelector` and `observeOptions` (see below).
 
     The recommended approach is to set this option to `false` and ensure the required cursor is specified in the `observers` array.
   
@@ -36,7 +38,7 @@ Meteor.publish('nameOfPublication', function() {
   - `debounceCount`: An integer representing the number of observer changes across all observers before the aggregation will be re-run. Defaults to 100. Used in conjunction with `debounceDelay` to fine-tune reactivity.
   - `debounceDelay`: An integer representing the maximum number of milli-seconds to wait for observer changes before the aggregation is re-run. Defaults to 100. Used in conjunction with `debounceCount` to fine-tune reactivity.
 
-  The following parameters are **deprecated** and will be removed in a later version. Both these parameters are now effectively absorbed into the `observers` option and if required should be added as a cursor (or another cursor) to the array of cursors in that. Setting either of these to anything other than the empty object `{}` will result in a deprecation notice to the server console.
+  :hand: The following parameters are **deprecated** and will be removed in a later version. Both these parameters are now effectively absorbed into the `observers` option and if required should be added as a cursor (or another cursor) to the array of cursors in that. Setting either of these to anything other than the empty object `{}` will result in a deprecation notice to the server console.
   - ~~`observeSelector` can be given to improve efficiency. This selector is used for observing the collection.
   (e.g. `{ authorId: { $exists: 1 } }`)~~
   - ~~`observeOptions` can be given to limit fields, further improving efficiency. Ideally used to limit fields on your query.
@@ -143,7 +145,7 @@ By default, only the base collection is observed for changes. However, it's poss
 
 ```js
 Meteor.publish("biographiesByWelshAuthors", function () {
-  ReactiveAggregate(this, Authors, [{
+  ReactiveAggregate(this, null, [{
     $lookup: {
       from: "books",
       localField: "_id",
@@ -151,7 +153,6 @@ Meteor.publish("biographiesByWelshAuthors", function () {
       as: "author_books"
     }
   }], {
-    autoObserver: false,
     observers: [
       Authors.find({ nationality: 'welsh'}),
       Books.find({ category: 'biography' })

--- a/README.md
+++ b/README.md
@@ -210,4 +210,4 @@ By mutating the `Reruns` collection on a specific `_id` we cause the aggregation
 
 ---
 
-Enjoy aggregating `reactively`!
+Enjoy aggregating reactively, but use sparingly. Remember, with great reactivity comes great responsibility!

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Reactively publish aggregations.
 
-    meteor add tunguska:reactive-aggregate
+`meteor add tunguska:reactive-aggregate`
 
 This helper can be used to reactively publish the results of an aggregation.
 
@@ -31,17 +31,17 @@ Meteor.publish('nameOfPublication', function() {
 - `options` provides further options:
   - `aggregationOptions` can be used to add further, aggregation-specific options. See [standard aggregation options](http://mongodb.github.io/node-mongodb-native/3.1/api/Collection.html#aggregate) for more information.
   - `clientCollection` defaults to the same name as the original collection, but can be overridden to send the results to a differently named client-side collection.
-  - `noAutomaticObserver`: set to `true` to prevent the backwards-compatible behaviour of an observer on the given collection.
+  - `noAutomaticObserver`: set this to `true` to prevent the backwards-compatible behaviour of an observer on the given collection.
   - `observers`: An array of cursors. Each cursor is the result of a `Collection.find()`. Each of the supplied cursors will have an observer attached, so any change detected (based on the selection criteria in the `find`) will re-run the aggregation pipeline.
-  - `debounceCount`: An integer representing the number of observer changes across all observers before the aggregation will be re-run. Defaults to 100. Used in conjunction with `debounceDelay` to fine-tune reactivity. The first of the two debounce options to be reached will re-run the aggregation.
-  - `debounceDelay`: An integer representing the maximum number of milli-seconds to wait for observer changes before the aggregation is re-run. Defaults to 100. Used in conjunction with `debounceCount` to fine-tune reactivity. The first of the two debounce options to be reached will re-run the aggregation.
+  - `debounceCount`: An integer representing the number of observer changes across all observers before the aggregation will be re-run. Defaults to 0 (do not count) for backwards compatibility with the original API. Used in conjunction with `debounceDelay` to fine-tune reactivity. The first of the two debounce options to be reached will re-run the aggregation.
+  - `debounceDelay`: An integer representing the maximum number of milli-seconds to wait for observer changes before the aggregation is re-run. Defaults to 0 (do not wait) for backwards compatibility with the original API. Used in conjunction with `debounceCount` to fine-tune reactivity. The first of the two debounce options to be reached will re-run the aggregation.
 
-  :hand: The following parameters are **deprecated** and will be removed in a later version. Both these parameters are now effectively absorbed into the `observers` option and if required should be replaced by adding a cursor (or cursors) to the array of cursors in `observers`. Setting either of these to anything other than the empty object `{}` will result in a deprecation notice to the server console.
-  - ~~`observeSelector` can be given to improve efficiency. This selector is used for observing the collection.
-  (e.g. `{ authorId: { $exists: 1 } }`)~~
-  - ~~`observeOptions` can be given to limit fields, further improving efficiency. Ideally used to limit fields on your query.
+  :hand: The following parameters are **deprecated** and will be removed in a later version. Both these parameters are now effectively absorbed into the `observers` option and if required should be replaced by adding a cursor (or cursors) to the array of cursors in `observers`. Setting either of these to anything other than the empty object `{}` will result in a deprecation notice to the server console (for example: `tunguska:reactive-aggregate: observeSelector is deprecated`).
+  - ~~`observeSelector`~~ can be given to improve efficiency. This selector is used for observing the collection.
+  (e.g. `{ authorId: { $exists: 1 } }`)
+  - ~~`observeOptions`~~ can be given to limit fields, further improving efficiency. Ideally used to limit fields on your query.
   If none are given any change to the collection will cause the aggregation to be re-evaluated.
-  (e.g. `{ limit: 10, sort: { createdAt: -1 } }`)~~
+  (e.g. `{ limit: 10, sort: { createdAt: -1 } }`)
 
 ## Quick Example
 
@@ -73,7 +73,7 @@ export const Reports = new Mongo.Collection('Reports');
 
 Next, prepare to publish the aggregation on the `Reports` collection into another client-side-only collection we'll call `clientReport`.
 
-Create the `clientReport` in the client side (it's needed only for client use). This collection will be the destination into which the aggregation will be put upon completion.
+Create the `clientReport` in the client (it's needed only for client use). This collection will be the destination into which the aggregation will be put upon completion.
 
 Publish the aggregation on the server:
 
@@ -138,7 +138,7 @@ Your aggregated values will therefore be available in the client and behave reac
 
 The use of `$lookup` in an aggregation pipeline introduces the eventuality that the aggregation pipeline will need to re-run when any or all of the collections involved in the aggregation change.
 
-By default, only the base collection is observed for changes. However, it's possible to specify an arbitrary number of observers on disparate collections. In fact, it's possible to observe a collection which is not part of the aggregation pipeline to trigger a re-run of the aggregation. This introduces some interesting approaches towards optimising "heavy" pipelines on very active collections (although perhaps you shouldn't be doing that in the first place).
+By default, only the base collection is observed for changes. However, it's possible to specify an arbitrary number of observers on disparate collections. In fact, it's possible to observe a collection which is not part of the aggregation pipeline to trigger a re-run of the aggregation. This introduces some interesting approaches towards optimising "heavy" pipelines on very active collections (although perhaps you shouldn't be doing that in the first place :wink:).
 
 ```js
 Meteor.publish("biographiesByWelshAuthors", function () {
@@ -151,6 +151,8 @@ Meteor.publish("biographiesByWelshAuthors", function () {
     }
   }], {
     noAutomaticObserver: true,
+    debounceCount: 100,
+    debounceDelay: 100,
     observers: [
       Authors.find({ nationality: 'welsh'}),
       Books.find({ category: 'biography' })
@@ -161,7 +163,7 @@ Meteor.publish("biographiesByWelshAuthors", function () {
 
 The aggregation will re-run whenever there is a change to the "welsh" authors in the `authors` collection or if there is a change to the biographies in the `books` collection.
 
-No `debounce` parameters have been specified, so any changes will only be made available to the client when 100 changes have been seen across both collections, or after 100mS, whichever occurs first.
+The `debounce` parameters were been specified, so any changes will only be made available to the client when 100 changes have been seen across both collections (in total), or after 100ms, whichever occurs first.
 
 ## Non-Reactive Aggregations
 

--- a/aggregate.js
+++ b/aggregate.js
@@ -50,7 +50,8 @@ export const ReactiveAggregate = (sub, collection = null, pipeline = [], options
     throw new TunguskaReactiveAggregateError('options.observers must be an array');
   } else {
     localOptions.observers.forEach((cursor, i) => {
-      if (!(cursor instanceof Mongo.Collection.Cursor)) {
+      // The obvious "cursor instanceof Mongo.Cursor" doesn't seem to work
+      if (!(cursor._cursorDescription && cursor._cursorDescription.collectionName)) {
         throw new TunguskaReactiveAggregateError(`options.observers[${i}] must be a cursor`);
       }
     });

--- a/aggregate.js
+++ b/aggregate.js
@@ -7,17 +7,17 @@ export const ReactiveAggregate = (sub, collection = null, pipeline = [], options
   const TunguskaReactiveAggregateError = Meteor.makeErrorType('tunguska:reactive-aggregate', function(msg) {
     this.message = `: ${msg}`;
     this.path = '';
-    this.sanitizedError = new Meteor.Error('Error', msg.replace(/: .*$/, ''));
+    this.sanitizedError = new Meteor.Error('Error', 'tunguska:reactive-aggregate');
   });
 
   // Check inbound parameter types
-  if (collection !== null && !collection instanceof Mongo.Collection) {
+  if (!(collection instanceof Mongo.Collection)) {
     throw new TunguskaReactiveAggregateError('collection must be a Mongo.Collection');
   }
-  if (!pipeline instanceof Array) {
+  if (!(pipeline instanceof Array)) {
     throw new TunguskaReactiveAggregateError('pipeline must be an array');
   }
-  if (!options instanceof Object) {
+  if (!(options instanceof Object)) {
     throw new TunguskaReactiveAggregateError('options must be an object');
   }
 
@@ -40,22 +40,22 @@ export const ReactiveAggregate = (sub, collection = null, pipeline = [], options
   if (typeof localOptions.noAutomaticObserver !== 'boolean') {
     throw new TunguskaReactiveAggregateError('options.noAutomaticObserver must be true or false');
   }
-  if (!options.observeSelector instanceof Object) {
+  if (!(options.observeSelector instanceof Object)) {
     throw new TunguskaReactiveAggregateError('deprecated options.observeSelector must be an object');
   }
-  if (!options.observeOptions instanceof Object) {
+  if (!(options.observeOptions instanceof Object)) {
     throw new TunguskaReactiveAggregateError('deprecated options.observeOptions must be an object');
   }
-  if (!options.observers instanceof Array) {
+  if (!(options.observers instanceof Array)) {
     throw new TunguskaReactiveAggregateError('options.observers must be an array');
   } else {
     options.observers.forEach((cursor, i) => {
-      if (!cursor instanceof Mongo.Cursor) {
+      if (!(cursor instanceof Mongo.Cursor)) {
         throw new TunguskaReactiveAggregateError(`options.observers[${i}] must be a cursor`);
       }
     });
   }
-  if (!typeof options.debounceCount === 'number') {
+  if (!(typeof options.debounceCount === 'number')) {
     throw new TunguskaReactiveAggregateError('options.debounceCount must be a positive integer');
   } else {
     options.debounceCount = parseInt(options.debounceCount, 10);
@@ -63,7 +63,7 @@ export const ReactiveAggregate = (sub, collection = null, pipeline = [], options
       throw new TunguskaReactiveAggregateError('options.debounceCount must be a positive integer');
     }
   }
-  if (!typeof options.debounceDelay === 'number') {
+  if (!(typeof options.debounceDelay === 'number')) {
     throw new TunguskaReactiveAggregateError('options.debounceDelay must be a positive integer');
   } else {
     options.debounceDelay = parseInt(options.debounceDelay, 10);

--- a/aggregate.js
+++ b/aggregate.js
@@ -72,7 +72,7 @@ export const ReactiveAggregate = (sub, collection, pipeline, options) => {
 
   const handles = [];
   // track any changes on the observed cursors
-  localOptions.obervers.forEach((query) => {
+  localOptions.observers.forEach((query) => {
     handles.push(query.observeChanges({
       added: debounce,
       changed: debounce,

--- a/aggregate.js
+++ b/aggregate.js
@@ -40,34 +40,34 @@ export const ReactiveAggregate = (sub, collection = null, pipeline = [], options
   if (typeof localOptions.noAutomaticObserver !== 'boolean') {
     throw new TunguskaReactiveAggregateError('options.noAutomaticObserver must be true or false');
   }
-  if (typeof options.observeSelector !== 'object') {
+  if (typeof localOptions.observeSelector !== 'object') {
     throw new TunguskaReactiveAggregateError('deprecated options.observeSelector must be an object');
   }
-  if (typeof options.observeOptions !== 'object') {
+  if (typeof localOptions.observeOptions !== 'object') {
     throw new TunguskaReactiveAggregateError('deprecated options.observeOptions must be an object');
   }
-  if (!(options.observers instanceof Array)) {
+  if (!(localOptions.observers instanceof Array)) {
     throw new TunguskaReactiveAggregateError('options.observers must be an array');
   } else {
-    options.observers.forEach((cursor, i) => {
+    localOptions.observers.forEach((cursor, i) => {
       if (!(cursor instanceof Mongo.Cursor)) {
         throw new TunguskaReactiveAggregateError(`options.observers[${i}] must be a cursor`);
       }
     });
   }
-  if (!(typeof options.debounceCount === 'number')) {
+  if (!(typeof localOptions.debounceCount === 'number')) {
     throw new TunguskaReactiveAggregateError('options.debounceCount must be a positive integer');
   } else {
-    options.debounceCount = parseInt(options.debounceCount, 10);
-    if (options.debounceCount < 0) {
+    localOptions.debounceCount = parseInt(localOptions.debounceCount, 10);
+    if (localOptions.debounceCount < 0) {
       throw new TunguskaReactiveAggregateError('options.debounceCount must be a positive integer');
     }
   }
-  if (!(typeof options.debounceDelay === 'number')) {
+  if (!(typeof localOptions.debounceDelay === 'number')) {
     throw new TunguskaReactiveAggregateError('options.debounceDelay must be a positive integer');
   } else {
-    options.debounceDelay = parseInt(options.debounceDelay, 10);
-    if (options.debounceDelay < 0) {
+    localOptions.debounceDelay = parseInt(localOptions.debounceDelay, 10);
+    if (localOptions.debounceDelay < 0) {
       throw new TunguskaReactiveAggregateError('options.debounceDelay must be a positive integer');
     }
   }
@@ -126,7 +126,7 @@ export const ReactiveAggregate = (sub, collection = null, pipeline = [], options
     }
   }
 
-  if (!options.noAutomaticObserver) {
+  if (!localOptions.noAutomaticObserver) {
     const query = collection.find(localOptions.observeSelector, localOptions.observeOptions);
     localOptions.observers.push(query);
   }

--- a/aggregate.js
+++ b/aggregate.js
@@ -40,10 +40,10 @@ export const ReactiveAggregate = (sub, collection = null, pipeline = [], options
   if (typeof localOptions.noAutomaticObserver !== 'boolean') {
     throw new TunguskaReactiveAggregateError('options.noAutomaticObserver must be true or false');
   }
-  if (!(options.observeSelector instanceof Object)) {
+  if (typeof options.observeSelector !== 'object') {
     throw new TunguskaReactiveAggregateError('deprecated options.observeSelector must be an object');
   }
-  if (!(options.observeOptions instanceof Object)) {
+  if (typeof options.observeOptions !== 'object') {
     throw new TunguskaReactiveAggregateError('deprecated options.observeOptions must be an object');
   }
   if (!(options.observers instanceof Array)) {

--- a/aggregate.js
+++ b/aggregate.js
@@ -94,7 +94,7 @@ export const ReactiveAggregate = (sub, collection, pipeline, options) => {
   // stop observing the cursors when the client unsubscribes
   sub.onStop(function () {
     handles.forEach(handle => {
-      stop();
+      handle.stop();
     });
   });
 };

--- a/aggregate.js
+++ b/aggregate.js
@@ -50,7 +50,7 @@ export const ReactiveAggregate = (sub, collection = null, pipeline = [], options
     throw new TunguskaReactiveAggregateError('options.observers must be an array');
   } else {
     localOptions.observers.forEach((cursor, i) => {
-      if (!(cursor instanceof Mongo.Cursor)) {
+      if (!(cursor instanceof Mongo.Collection.Cursor)) {
         throw new TunguskaReactiveAggregateError(`options.observers[${i}] must be a cursor`);
       }
     });

--- a/aggregate.js
+++ b/aggregate.js
@@ -27,13 +27,13 @@ export const ReactiveAggregate = (sub, collection = null, pipeline = [], options
   // Set up local options based on defaults and supplied options
   const localOptions = {
     ...{
-      noAutomaticObserver: true,
+      noAutomaticObserver: false,
       aggregationOptions: {},
       observeSelector: {},
       observeOptions: {},
       observers: [], // cursor1, ... cursorn
-      debounceCount: 100,
-      debounceDelay: 100, // mS
+      debounceCount: 0,
+      debounceDelay: 0, // mS
       clientCollection: collection._name,
     },
     ...options
@@ -123,7 +123,7 @@ export const ReactiveAggregate = (sub, collection = null, pipeline = [], options
   const debounce = () => {
     if (initializing) return;
     if (!timer && localOptions.debounceCount > 0) timer = Meteor.setTimeout(update, localOptions.debounceDelay);
-    if (currentDebounceCount++ > localOptions.debounceCount) {
+    if (++currentDebounceCount > localOptions.debounceCount) {
       currentDebounceCount = 0;
       Meteor.clearTimeout(timer);
       update();

--- a/aggregate.js
+++ b/aggregate.js
@@ -5,7 +5,7 @@ export const ReactiveAggregate = (sub, collection = null, pipeline = [], options
 
   // Define new Meteor Error type
   const TunguskaReactiveAggregateError = Meteor.makeErrorType('tunguska:reactive-aggregate', function(msg) {
-    this.message = `: ${msg}`;
+    this.message = msg;
     this.path = '';
     this.sanitizedError = new Meteor.Error('Error', 'tunguska:reactive-aggregate');
   });

--- a/aggregate.js
+++ b/aggregate.js
@@ -1,18 +1,26 @@
 export const ReactiveAggregate = (sub, collection, pipeline, options) => {
-  import {
-    Promise
-  } from 'meteor/promise';
-  const defaultOptions = {
-    aggregationOptions: {},
-    observeSelector: {},
-    observeOptions: {},
-    observers: [], // cursor1, ... cursorn
-    debounceDelay: 100, // mS
-    debounceCount: 100,
-    clientCollection: collection._name
-  };
-  defaultOptions = { ...defaultOptions, ...options };
+  import { Meteor } from 'meteor/meteor';
+  import { Promise } from 'meteor/promise';
 
+  const localOptions = {
+    ...{
+      autoObserver: true,
+      aggregationOptions: {},
+      observeSelector: {},
+      observeOptions: {},
+      observers: [], // cursor1, ... cursorn
+      debounceDelay: 100, // mS
+      debounceCount: 100,
+      clientCollection: collection._name
+    },
+    ...options
+  };
+
+  if (Object.keys(localOptions.observeSelector).length != 0) console.log('tunguska:reactive-aggregate observeSelector is deprecated');
+  if (Object.keys(localOptions.observeOptions).length != 0) console.log('tunguska:reactive-aggregate observeOptions is deprecated');
+
+  // observeChanges() will immediately fire an "added" event for each document in the query
+  // these are skipped using the initializing flag
   let initializing = true;
   sub._ids = {};
   sub._iteration = 1;
@@ -21,12 +29,12 @@ export const ReactiveAggregate = (sub, collection, pipeline, options) => {
     if (initializing) return;
     // add and update documents on the client
     try {
-      const docs = await collection.rawCollection().aggregate(pipeline, options.aggregationOptions).toArray();
+      const docs = await collection.rawCollection().aggregate(pipeline, localOptions.aggregationOptions).toArray();
       docs.forEach(doc => {
         if (!sub._ids[doc._id]) {
-          sub.added(options.clientCollection, doc._id, doc);
+          sub.added(localOptions.clientCollection, doc._id, doc);
         } else {
-          sub.changed(options.clientCollection, doc._id, doc);
+          sub.changed(localOptions.clientCollection, doc._id, doc);
         }
         sub._ids[doc._id] = sub._iteration;
       });
@@ -35,7 +43,7 @@ export const ReactiveAggregate = (sub, collection, pipeline, options) => {
       Object.keys(sub._ids).forEach(id => {
         if (sub._ids[id] !== sub._iteration) {
           delete sub._ids[id];
-          sub.removed(options.clientCollection, id);
+          sub.removed(localOptions.clientCollection, id);
         }
       });
       sub._iteration++;
@@ -49,7 +57,7 @@ export const ReactiveAggregate = (sub, collection, pipeline, options) => {
 
   const debounce = () => {
     if (initializing) return;
-    if (!timer) timer = Meteor.setTimeout(update, options.debounceDelay);
+    if (!timer && localOptions.debounceCount > 0) timer = Meteor.setTimeout(update, localOptions.debounceDelay);
     if (currentDebounceCount++ > localOptions.debounceCount) {
       currentDebounceCount = 0;
       Meteor.clearTimeout(timer);
@@ -57,26 +65,36 @@ export const ReactiveAggregate = (sub, collection, pipeline, options) => {
     }
   }
 
-  // track any changes on the collection used for the aggregation
-  const query = collection.find(options.observeSelector, options.observeOptions);
-  const handle = query.observeChanges({
-    added: debounce,
-    changed: debounce,
-    removed: debounce,
-    error(err) {
-      throw err;
-    }
+  if (localOptions.autoObserver) {
+    const query = collection.find(localOptions.observeSelector, localOptions.observeOptions);
+    localOptions.observers.push(query);
+  }
+
+  const handles = [];
+  // track any changes on the observed cursors
+  localOptions.obervers.forEach((query) => {
+    handles.push(query.observeChanges({
+      added: debounce,
+      changed: debounce,
+      removed: debounce,
+      error(err) {
+        throw err;
+      }
+    }));
   });
-  // observeChanges() will immediately fire an "added" event for each document in the query
-  // these are skipped using the initializing flag
+  // End of the setup phase.
+  
+  // Clear the initializing flag. From here, we're on autopilot
   initializing = false;
   // send an initial result set to the client
   Promise.await(update());
   // mark the subscription as ready
   sub.ready();
 
-  // stop observing the cursor when the client unsubscribes
+  // stop observing the cursors when the client unsubscribes
   sub.onStop(function () {
-    handle.stop();
+    handles.forEach(handle => {
+      stop();
+    });
   });
 };

--- a/aggregate.js
+++ b/aggregate.js
@@ -11,14 +11,17 @@ export const ReactiveAggregate = (sub, collection = null, pipeline = [], options
   });
 
   // Check inbound parameter types
+  if (!(sub && sub.ready && sub.stop)) {
+    throw new TunguskaReactiveAggregateError('unexpected context - did you set "sub" to "this"?');
+  }
   if (!(collection instanceof Mongo.Collection)) {
-    throw new TunguskaReactiveAggregateError('collection must be a Mongo.Collection');
+    throw new TunguskaReactiveAggregateError('"collection" must be a Mongo.Collection');
   }
   if (!(pipeline instanceof Array)) {
-    throw new TunguskaReactiveAggregateError('pipeline must be an array');
+    throw new TunguskaReactiveAggregateError('"pipeline" must be an array');
   }
   if (!(options instanceof Object)) {
-    throw new TunguskaReactiveAggregateError('options must be an object');
+    throw new TunguskaReactiveAggregateError('"options" must be an object');
   }
 
   // Set up local options based on defaults and supplied options
@@ -38,42 +41,42 @@ export const ReactiveAggregate = (sub, collection = null, pipeline = [], options
 
   // Check options
   if (typeof localOptions.noAutomaticObserver !== 'boolean') {
-    throw new TunguskaReactiveAggregateError('options.noAutomaticObserver must be true or false');
+    throw new TunguskaReactiveAggregateError('"options.noAutomaticObserver" must be true or false');
   }
   if (typeof localOptions.observeSelector !== 'object') {
-    throw new TunguskaReactiveAggregateError('deprecated options.observeSelector must be an object');
+    throw new TunguskaReactiveAggregateError('deprecated "options.observeSelector" must be an object');
   }
   if (typeof localOptions.observeOptions !== 'object') {
-    throw new TunguskaReactiveAggregateError('deprecated options.observeOptions must be an object');
+    throw new TunguskaReactiveAggregateError('deprecated "options.observeOptions" must be an object');
   }
   if (!(localOptions.observers instanceof Array)) {
-    throw new TunguskaReactiveAggregateError('options.observers must be an array of cursors');
+    throw new TunguskaReactiveAggregateError('"options.observers" must be an array of cursors');
   } else {
     localOptions.observers.forEach((cursor, i) => {
       // The obvious "cursor instanceof Mongo.Cursor" doesn't seem to work, so...
       if (!(cursor._cursorDescription && cursor._cursorDescription.collectionName)) {
-        throw new TunguskaReactiveAggregateError(`options.observers[${i}] must be a cursor`);
+        throw new TunguskaReactiveAggregateError(`"options.observers[${i}]" must be a cursor`);
       }
     });
   }
   if (!(typeof localOptions.debounceCount === 'number')) {
-    throw new TunguskaReactiveAggregateError('options.debounceCount must be a positive integer');
+    throw new TunguskaReactiveAggregateError('"options.debounceCount" must be a positive integer');
   } else {
     localOptions.debounceCount = parseInt(localOptions.debounceCount, 10);
     if (localOptions.debounceCount < 0) {
-      throw new TunguskaReactiveAggregateError('options.debounceCount must be a positive integer');
+      throw new TunguskaReactiveAggregateError('"options.debounceCount" must be a positive integer');
     }
   }
   if (!(typeof localOptions.debounceDelay === 'number')) {
-    throw new TunguskaReactiveAggregateError('options.debounceDelay must be a positive integer');
+    throw new TunguskaReactiveAggregateError('"options.debounceDelay" must be a positive integer');
   } else {
     localOptions.debounceDelay = parseInt(localOptions.debounceDelay, 10);
     if (localOptions.debounceDelay < 0) {
-      throw new TunguskaReactiveAggregateError('options.debounceDelay must be a positive integer');
+      throw new TunguskaReactiveAggregateError('"options.debounceDelay" must be a positive integer');
     }
   }
   if (typeof localOptions.clientCollection !== 'string') {
-    throw new TunguskaReactiveAggregateError('options.clientCollection must be a string');
+    throw new TunguskaReactiveAggregateError('"options.clientCollection" must be a string');
   }
   
   
@@ -144,7 +147,7 @@ export const ReactiveAggregate = (sub, collection = null, pipeline = [], options
       }
     }));
   });
-  // End of the setup phase.
+  // End of the setup phase. We don't need to do any of that again!
   
   // Clear the initializing flag. From here, we're on autopilot
   initializing = false;

--- a/aggregate.js
+++ b/aggregate.js
@@ -11,9 +11,7 @@ export const ReactiveAggregate = (sub, collection, pipeline, options) => {
     debounceCount: 100,
     clientCollection: collection._name
   };
-  const localOptions = _.extend(defaultOptions, options);
-
-  let currentDebounceCount = 0;
+  defaultOptions = { ...defaultOptions, ...options };
 
   let initializing = true;
   sub._ids = {};
@@ -46,12 +44,15 @@ export const ReactiveAggregate = (sub, collection, pipeline, options) => {
     }
   }
 
+  let currentDebounceCount = 0;
+  let timer;
+
   const debounce = () => {
     if (initializing) return;
-    const timer = Meteor.setTimeout(update, options.debounceDelay);
+    if (!timer) timer = Meteor.setTimeout(update, options.debounceDelay);
     if (currentDebounceCount++ > localOptions.debounceCount) {
       currentDebounceCount = 0;
-      Meteor.cancelTimeout(timer);
+      Meteor.clearTimeout(timer);
       update();
     }
   }

--- a/aggregate.js
+++ b/aggregate.js
@@ -1,23 +1,39 @@
-export const ReactiveAggregate = (sub, collection, pipeline, options) => {
+export const ReactiveAggregate = (sub, collection = null, pipeline = [], options = {}) => {
   import { Meteor } from 'meteor/meteor';
+  import { Mongo } from 'meteor/mongo';
   import { Promise } from 'meteor/promise';
+
+  if (collection !== null && collection !== instanceof Mongo.Collection) {
+    throw new Error('E-collection', 'tunguska:reactive-aggregate: collection must be null or a Mongo.Collection');
+  }
+
+  if (pipeline !== instanceof Array) {
+    throw new Error('E-pipeline', 'tunguska:reactive-aggregate: pipeline must be an array');
+  }
+
+  if (options !== instanceof Object) {
+    throw new Error('E-options', 'tunguska:reactive-aggregate: options must be an object');
+  }
 
   const localOptions = {
     ...{
-      autoObserver: true,
       aggregationOptions: {},
       observeSelector: {},
       observeOptions: {},
       observers: [], // cursor1, ... cursorn
       debounceDelay: 100, // mS
       debounceCount: 100,
-      clientCollection: collection._name
     },
     ...options
   };
 
-  if (Object.keys(localOptions.observeSelector).length != 0) console.log('tunguska:reactive-aggregate observeSelector is deprecated');
-  if (Object.keys(localOptions.observeOptions).length != 0) console.log('tunguska:reactive-aggregate observeOptions is deprecated');
+  localOptions.clientCollection = collection === null ? null : collection._name;
+  if (typeof localOptions.clientCollection !== 'string') {
+    throw new Error('E-clientCollection', 'tunguska:reactive-aggregate: options.clientCollection must be specified if collection is null');
+  }
+
+  if (Object.keys(localOptions.observeSelector).length != 0) console.log('tunguska:reactive-aggregate: observeSelector is deprecated');
+  if (Object.keys(localOptions.observeOptions).length != 0) console.log('tunguska:reactive-aggregate: observeOptions is deprecated');
 
   // observeChanges() will immediately fire an "added" event for each document in the query
   // these are skipped using the initializing flag
@@ -48,7 +64,7 @@ export const ReactiveAggregate = (sub, collection, pipeline, options) => {
       });
       sub._iteration++;
     } catch (err) {
-      throw err;
+      throw new Error ('E-pub', `tunguska:reactive-aggregate: ${err.message}`);
     }
   }
 
@@ -65,7 +81,7 @@ export const ReactiveAggregate = (sub, collection, pipeline, options) => {
     }
   }
 
-  if (localOptions.autoObserver) {
+  if (collection !== null) {
     const query = collection.find(localOptions.observeSelector, localOptions.observeOptions);
     localOptions.observers.push(query);
   }

--- a/package.js
+++ b/package.js
@@ -10,7 +10,6 @@ Package.onUse(function(api) {
   api.versionsFrom('1.5');
   api.use('mongo');
   api.use('ecmascript');
-  api.use('underscore');
   api.use('promise');
   api.mainModule('aggregate.js', 'server');
 });

--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'tunguska:reactive-aggregate',
-  version: '1.0.4',
+  version: '1.1.0',
   summary: 'Reactively publish aggregations.',
   git: 'https://github.com/robfallows/tunguska-reactive-aggregate',
   documentation: 'README.md'

--- a/package.js
+++ b/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: 'tunguska:reactive-aggregate',
   version: '1.1.0',
-  summary: 'Reactively publish aggregations.',
+  summary: 'Publish aggregations reactively',
   git: 'https://github.com/robfallows/tunguska-reactive-aggregate',
   documentation: 'README.md'
 });


### PR DESCRIPTION
Fixes #5.

Fixes #9.

## Testing this PR:

- Ensure your current project code is committed.
- Create a `packages` folder in the root of your project, if you don't already have one.
- Clone this repo into a new subdirectory of `packages`. For example `packages/reactive-aggregate`:

       git clone git@github.com:robfallows/tunguska-reactive-aggregate.git packages/reactive-aggregate

- Refer to the [revised documentation](https://github.com/robfallows/tunguska-reactive-aggregate/blob/allow-multiple-collection-observers/README.md) and modify your code as required.
- Run Meteor to rebuild your project.
- Check desired behaviour.
- Feedback your findings to this PR's discussion thread.

## After Testing

Revert your codebase to its pre-PR state.