### PR TITLE
Update aggregate.js to handle removed fields

### DIFF
--- a/aggregate.js
+++ b/aggregate.js
@@ -126,6 +126,15 @@ export const ReactiveAggregate = (sub, collection = null, pipeline = [], options
         if (!sub._ids[doc_id]) {
           sub.added(localOptions.clientCollection, doc_id, doc);
         } else {
+          // Since the pipeline fields might have been removed, we need to find the differences and define them as 'undefined' so the sub removes them.
+          let previousFields = [...sub._session.collectionViews.get(localOptions.clientCollection).documents.get(doc_id).dataByKey.keys()];
+          previousFields.forEach(field => {
+            // At this point they are undefined because they no longer exist in the new doc, they're not literally set as undefined
+            if(doc[field] === undefined){
+              // We need to explicitly define this as undefined so the sub will remove them.
+              doc[field] = undefined;
+            }
+          })
           sub.changed(localOptions.clientCollection, doc_id, doc);
         }
         sub._ids[doc_id] = sub._iteration;

--- a/aggregate.js
+++ b/aggregate.js
@@ -127,7 +127,7 @@ export const ReactiveAggregate = (sub, collection = null, pipeline = [], options
           sub.added(localOptions.clientCollection, doc_id, doc);
         } else {
           // Since the pipeline fields might have been removed, we need to find the differences and define them as 'undefined' so the sub removes them.
-          let previousFields = [...sub._session.collectionViews.get(localOptions.clientCollection).documents.get(doc_id).dataByKey.keys()];
+          const previousFields = [...sub._session.collectionViews.get(localOptions.clientCollection).documents.get(doc_id).dataByKey.keys()];
           previousFields.forEach(field => {
             // At this point they are undefined because they no longer exist in the new doc, they're not literally set as undefined
             if(doc[field] === undefined){


### PR DESCRIPTION
When a pipeline document is updated and the updated document has fields removed, the subscription isn't removing the fields.

See https://github.com/robfallows/tunguska-reactive-aggregate/issues/23 for full context.