### PR TITLE
Add optional transform function to options

### DIFF
--- a/aggregate.js
+++ b/aggregate.js
@@ -109,6 +109,11 @@ export const ReactiveAggregate = (sub, collection = null, pipeline = [], options
           ObjectIds coming via toArray() become POJOs
         */
 
+        // Run optional transform function to make further changes on doc before sending it to client.
+        if (options.hasOwnProperty("transform")) {
+          options.transform(doc);
+        }
+
         let doc_id;
         if (!doc._id) { // missing or otherwise falsy
           throw new TunguskaReactiveAggregateError('every aggregation document must have an _id');


### PR DESCRIPTION
I needed to make changes to aggregate results before sending it to the client. 

In my use case, I needed to further modify the aggregation results and calculate the result of a number of fields via math library `extact-math` which was difficult for me to do in mongo. 

I have added an optional function to be executed before sending the document to mini mongo. 

```
import { ReactiveAggregate } from 'meteor/tunguska:reactive-aggregate';

Meteor.publish('nameOfPublication', function() {
  ReactiveAggregate(sub, collection, pipeline, {
      transform: doc => {
          // make changes here
      }
  });
});
```