### PR TITLE
Only display dependency errors once (fixes issue #40)

### DIFF
--- a/aggregate.js
+++ b/aggregate.js
@@ -1,3 +1,4 @@
+let _errorsDisplayedOnce = false;
 export const ReactiveAggregate = (sub, collection = null, pipeline = [], options = {}) => {
   import { Meteor } from 'meteor/meteor';
   import { Mongo } from 'meteor/mongo';
@@ -18,9 +19,10 @@ export const ReactiveAggregate = (sub, collection = null, pipeline = [], options
   }
   try { _CircDepPreventionSimpleSchema = require('simpl-schema'); } catch (e) { packageErrors.push({name:'simpl-schema',error:e}); }
   const isUsingMongoObjectIDSupport = packageErrors.length === 0;
-  if ( !isUsingMongoObjectIDSupport ) {
+  if ( !isUsingMongoObjectIDSupport && !_errorsDisplayedOnce ) {
     console.log(`ReactiveAggregate support for Mongo.ObjectID is disabled due to ${packageErrors.length} package error(s):`);
     packageErrors.forEach( (e,i) => { console.log( `   ${i+1} - ${e.name}: ${e.error.code || e.error}`);});
+    _errorsDisplayedOnce = true;
   }  
 
   // Define new Meteor Error type

--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'tunguska:reactive-aggregate',
-  version: '1.3.1',
+  version: '1.3.2',
   summary: 'Publish aggregations reactively',
   git: 'https://github.com/robfallows/tunguska-reactive-aggregate',
   documentation: 'README.md'


### PR DESCRIPTION
instead of displaying the message every time ReactiveAggregate is used in a meteor project it will now only log the information to the console once.