### PR TITLE
Fix error when removing non-existing documents, Support for multiple ReactiveAggregates per subscription

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .versions
 .log
+.idea

--- a/History.md
+++ b/History.md
@@ -1,5 +1,11 @@
 # Change History
 
+## v1.3.15 2024-03-04
+
+- Fixes error when removing non-existing documents from collection
+- Support for multiple ReactiveAggregates per subscription
+- Ref https://github.com/robfallows/tunguska-reactive-aggregate/issues/76
+
 ## v1.3.14 2024-03-04
 
 - Fixes a [regression issue](https://github.com/robfallows/tunguska-reactive-aggregate/issues/80).

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# tunguska-reactive-aggregate v1.3.14
+# tunguska-reactive-aggregate v1.3.15
 
 Reactively publish aggregations.
 

--- a/aggregate.js
+++ b/aggregate.js
@@ -269,8 +269,12 @@ export const ReactiveAggregate = (sub, collection = null, pipeline = [], options
       // remove documents not in the result anymore
       Object.keys(sub._ids).forEach(id => {
         if (sub._ids[id] !== sub._iteration) {
-          delete sub._ids[id];
-          sub.removed(localOptions.clientCollection, id);
+          // as we might have multiple client-only aggregates per subscription, with different ids of the same collection
+          // ensure we only remove docs from the actual Collection passed in the aggregation
+          if (sub._session.collectionViews.get(localOptions.clientCollection)?.documents.has(id)) {
+            delete sub._ids[id];
+            sub.removed(key, id);
+          }
         }
       });
       sub._iteration++;

--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'tunguska:reactive-aggregate',
-  version: '1.3.14',
+  version: '1.3.15',
   summary: 'Publish aggregations reactively',
   git: 'https://github.com/robfallows/tunguska-reactive-aggregate',
   documentation: 'README.md'


### PR DESCRIPTION
- Fix error when removing non-existing documents
- Support for multiple ReactiveAggregates per subscription

Fixes: https://github.com/robfallows/tunguska-reactive-aggregate/issues/76

Tested with 6 Subscriptions of the same collection, on the same subscription (with 5 client-only collections)