### PR TITLE
Fix (regression) error when documents are removed from collection

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,5 +1,9 @@
 # Change History
 
+## v1.3.16 2024-04-05
+
+- Fixes (regression) error when documents are removed from collection
+
 ## v1.3.15 2024-03-04
 
 - Fixes error when removing non-existing documents from collection

--- a/aggregate.js
+++ b/aggregate.js
@@ -273,7 +273,7 @@ export const ReactiveAggregate = (sub, collection = null, pipeline = [], options
           // ensure we only remove docs from the actual Collection passed in the aggregation
           if (sub._session.collectionViews.get(localOptions.clientCollection)?.documents.has(id)) {
             delete sub._ids[id];
-            sub.removed(key, id);
+            sub.removed(localOptions.clientCollection, id);
           }
         }
       });

--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'tunguska:reactive-aggregate',
-  version: '1.3.15',
+  version: '1.3.16',
   summary: 'Publish aggregations reactively',
   git: 'https://github.com/robfallows/tunguska-reactive-aggregate',
   documentation: 'README.md'


### PR DESCRIPTION
Version 1.3.15 (re)introduced a "key is not defined" error when documents are removed from the collection. This small change fixes it.